### PR TITLE
[WIP] Fix TextBox input focus loss in Blazor

### DIFF
--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
@@ -5,7 +5,8 @@
      @onpointerdown="OnPointerDown"
      @onpointerup="OnPointerUp"
      @onpointermove="OnPointerMove"
-     @onpointercancel="OnPointerCancel">
+     @onpointercancel="OnPointerCancel"
+     @onfocus="OnFocus">
     
     <canvas id="htmlCanvas" @ref="_htmlCanvas" @attributes="AdditionalAttributes"/>
 

--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
@@ -38,6 +38,7 @@ namespace Avalonia.Web.Blazor
 
         private bool _initialised;
         private bool _useGL;
+        private bool _inputElementFocused;
 
         [Inject] private IJSRuntime Js { get; set; } = null!;
 
@@ -222,6 +223,16 @@ namespace Avalonia.Web.Blazor
             _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyUp, e.Code, e.Key, GetModifiers(e));
         }
 
+        private void OnFocus(FocusEventArgs e)
+        {
+            // if focus has unexpectedly moved from the input element to the container element,
+            // shift it back to the input element
+            if (_inputElementFocused && _inputHelper is not null)
+            {
+                _inputHelper.Focus();
+            }
+        }
+
         private void OnInput(ChangeEventArgs e)
         {
             if (e.Value != null)
@@ -399,10 +410,12 @@ namespace Avalonia.Web.Blazor
             if (active)
             {
                 _inputHelper.Show();
+                _inputElementFocused = true;
                 _inputHelper.Focus();
             }
             else
             {
+                _inputElementFocused = false;
                 _inputHelper.Hide();
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Works around an annoying bug in the Blazor build that prevents typing characters into TextBox.

## What is the current behavior?
If you click on a TextBox right after a page is rendered it will visually appear like it has input focus, however when you try to type anything in no characters will be entered (backspace and delete work fine), in order to type in any characters you have to click inside the TextBox a second time.

## What is the updated/expected behavior with this PR?
You only need to click inside a TextBox once to begin typing in characters.

## How was the solution implemented (if it's not obvious)?

In `AvaloniaView.razor` the `inputElement` is a full page element that is used to capture character input that's passed through to the currently focused `TextBox`, in order for `inputElement` to receive input it must have input focus in the browser window. 

```html
<div id="container" class="avalonia-container" tabindex="0" oncontextmenu="return false;"
     @onwheel="OnWheel"
     @onkeydown="OnKeyDown"
     @onkeyup="OnKeyUp"
     @onpointerdown="OnPointerDown"
     @onpointerup="OnPointerUp"
     @onpointermove="OnPointerMove"
     @onpointercancel="OnPointerCancel"
     @onfocus="OnFocus">
    
    <canvas id="htmlCanvas" @ref="_htmlCanvas" @attributes="AdditionalAttributes"/>
    <div id="nativeControlsContainer" @ref="_nativeControlsContainer" />
    <input id="inputElement" @ref="_inputElement" type="text" @oninput="OnInput" 
        onpaste="return false;"
        oncopy="return false;" 
        oncut="return false;"/>
</div>
```

Avalonia will invoke `inputElement.focus()` whenever it gives a text input control like a TextBox input focus, but that doesn't seem to work right after the page is rendered. What happens is:
1. `document.activeElement` is the `container` element.
2. When you click in TextBox Avalonia invokes `inputElement.focus()`
3. `document.activeElement` changes to `inputElement`, then immediately changes back to `container` element (why that is I have no clue).
4. Avalonia renders the TextBox as if it has input focus, but the `inputElement` doesn't pass through any characters because it doesn't actually have input focus in the browser window.

This PR introduces a workaround that forces the input focus in the browser to remain on the `inputElement` while Avalonia is expecting to receive text input. It works by adding an event handler to the `container` element for the focus event, which fires when the `container` element gains input focus. The `focus` event doesn't bubble so the event handler will only be invoked when the `container` element gains focus (not some child element). The event handler for the focus event checks to see if the `inputElement` is supposed to have input focus, and if so invokes `inputElement.focus()`, this time around `document.activeElement` changes to `inputElement` and doesn't immediately switch back to the `container` element.
